### PR TITLE
Check GitHub workflow state

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -18,7 +18,7 @@ gems:
     workflows: [test.yml]
   - name: ruby/rake
     ci: github
-    workflows: [test.yml, macos.yml]
+    workflows: [test.yml]
   - name: ruby/ruby2_keywords
     ci: github
     workflows: [test.yml]
@@ -43,7 +43,7 @@ gems:
     workflows: [source-gem.yml]
   - name: rack/rack
     ci: github
-    workflows: [development.yml]
+    workflows: [test.yaml]
   - name: puma/puma
     ci: github
     workflows: [non_mri.yml]
@@ -57,7 +57,7 @@ gems:
     workflows: [workflow.yml]
   - name: socketry/console
     ci: github
-    workflows: [development.yml]
+    workflows: [test.yaml]
   - name: ffi/ffi
     ci: github
     workflows: [ci.yml]
@@ -93,7 +93,7 @@ gems:
     workflows: [daily-rubygems.yml, ubuntu-rubygems.yml]
   - name: socketry/async-container
     ci: github
-    workflows: [development.yml]
+    workflows: [test.yaml]
   - name: ruby-next/ruby-next
     ci: github
     workflows: [truffle-test.yml]

--- a/lib/gem_tracker/ci/github.rb
+++ b/lib/gem_tracker/ci/github.rb
@@ -12,6 +12,11 @@ class GemTracker::GitHubActions < GemTracker::CI
     statuses = []
     repo = get_repository()
     gem.workflows.each do |w|
+      workflow = get_workflow(w)
+      if workflow["state"] == "deleted"
+        raise "GitHub workflow #{w} is deleted"
+      end
+
       runs = get_workflow_runs(w, gem.branch || repo["default_branch"])
       runs.each do |r|
         # p r['created_at']
@@ -88,6 +93,14 @@ class GemTracker::GitHubActions < GemTracker::CI
     end
 
     jobs
+  end
+
+  def get_workflow(workflow_id)
+    # https://api.github.com/repos/rack/rack/actions/workflows/development.yml
+    url = "https://api.github.com/repos/#{gem.name}/actions/workflows/#{workflow_id}"
+    request(url) do |response|
+      JSON.parse(response.body)
+    end
   end
 
   def get_workflow_runs(workflow, branch)


### PR DESCRIPTION
Changes:
- check state of GitHub workflow and raise exception if it's deleted
- update workflow file names in `gems.yml`

I've noticed that status of some gems (e.g. async-container) is still Failed, but actually several recent builds are successful.
The workflow file name was renamed recently so the old workflow is failed forever and we don't get actual status of CI builds.

The first my attempt was to check whether workflow state is "active" or not. If a workflow file is renamed its status become deleted". But there are so other states e.g. "disabled_inactivity" (there is a case when there was no new builds in the lsat month) what is a pretty valid case. So I check only whether state os "deleted" to catch a case with file renaming.