### PR TITLE
Update Grape Github workflow name

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -137,7 +137,7 @@ gems:
     ci: travis
   - name: ruby-grape/grape
     ci: github
-    workflows: [test.yml]
+    workflows: [edge.yml]
   - name: cyu/rack-cors
     ci: travis
   - name: jeremyevans/roda


### PR DESCRIPTION
Fix status updating issue:

```
grape                 ? #<RuntimeError: no github run jobs found, workflows: ["test.yml"]>      
```

https://github.com/eregon/truffleruby-gem-tracker/actions/runs/3819878024/jobs/6497780501