### PR TITLE
Update workflow name for rubygems gem

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -93,7 +93,7 @@ gems:
     workflows: [ci.yml]
   - name: rubygems/rubygems
     ci: github
-    workflows: [daily-rubygems.yml, ubuntu-rubygems.yml]
+    workflows: [daily-rubygems.yml, rubygems.yml]
   - name: socketry/async-container
     ci: github
     workflows: [test.yaml]


### PR DESCRIPTION
Before

```
bin/gem_tracker status rubygems

rubygems ? #<RuntimeError: GitHub workflow ubuntu-rubygems.yml is deleted>
Failing CIs: rubygems/rubygems
```

After

```
bin/gem_tracker status rubygems

rubygems ✗ 09-01-2023 Rubygems (truffleruby-head)              https://github.com/rubygems/rubygems/actions/runs/3869575147/jobs/6595760252
rubygems ✓ 08-01-2023 Rubygems on Ubuntu (truffleruby-22)      https://github.com/rubygems/rubygems/actions/runs/3866453194/jobs/6590586612
Failing CIs: rubygems/rubygems
```

The issue is caused by https://github.com/rubygems/rubygems/pull/6249