### PR TITLE
Fix GitHub repository owner for sdoc gem

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -270,7 +270,7 @@ gems:
   - name: stripe/stripe-ruby
     ci: github
     workflows: [ci.yml]
-  - name: zzak/sdoc
+  - name: rails/sdoc
     ci: github
     workflows: [test.yml]
   # - name: gazay/gon


### PR DESCRIPTION
The sdoc gem repository was moved from `zzak/sdoc` to `rails/sdoc`

Before
```
{"message"=>"Moved Permanently",
 "url"=>
  "https://api.github.com/repositories/155632/actions/workflows/test.yml/runs?branch=",
 "documentation_url"=>"https://docs.github.com/v3/#http-redirects"}
sdoc                 ? #<RuntimeError: Couldn't find workflow runs jobs>                                     
```

After
```
sdoc                 ✓ 03-04-2023 test (truffleruby-head)                  https://github.com/rails/sdoc/actions/runs/4591582818/jobs/8107862355
```