### PR TITLE
Fix getting puma gem's status

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -56,7 +56,7 @@ gems:
     workflows: [test.yaml]
   - name: puma/puma
     ci: github
-    workflows: [non_mri.yml]
+    workflows: [tests.yaml]
   - name: ruby-concurrency/concurrent-ruby
     ci: github
     workflows: [ci.yml, experimental.yml]


### PR DESCRIPTION
A GitHub Actions workflow file (`non_mri.yml`) was deleted in [#2869](https://github.com/puma/puma/pull/2869). New file is `tests.yaml`.

```
bin/gem_tracker status puma
puma ✓ 17-04-2023 NON-MRI: ...                             https://github.com/puma/puma/actions/runs/4726505933/jobs/8386155502
```