### PR TITLE
Fix typo that causes NameError when HTTP request isn't successful

### DIFF
--- a/lib/gem_tracker/ci/github.rb
+++ b/lib/gem_tracker/ci/github.rb
@@ -125,9 +125,9 @@ class GemTracker::GitHubActions < GemTracker::CI
     end
   end
 
-  def get_workflow_runs(workflow, branch)
+  def get_workflow_runs(workflow_id, branch)
     # https://api.github.com/repos/rack/rack/actions/workflows/development.yml/runs
-    url = "https://api.github.com/repos/#{gem.name}/actions/workflows/#{workflow}/runs?branch=#{branch}"
+    url = "https://api.github.com/repos/#{gem.name}/actions/workflows/#{workflow_id}/runs?branch=#{branch}"
     request(url) do |response|
       unless response.code.start_with?("20") # expect 20x status
         raise "HTTP Error (#{response.code}) getting GitHub workflow (#{workflow_id}) runs: #{response.body}"


### PR DESCRIPTION
Fix the following issue:

```
typeprof             ? #<NameError: undefined local variable or method `workflow_id' for #<GemTracker::GitHubActions:0x00007fbf4c78f768 @gem=#<GemTracker::Gem:0x00007fbf4c78f808 @name="ruby/typeprof", @workflows=["main.yml"], @branch=nil, @expect=:pass, @pattern="truffleruby", @search_last_n_builds=1, @ci=#<GemTracker::GitHubActions:0x00007fbf4c78f768 ...>>>

        raise "HTTP Error (#{response.code}) getting GitHub workflow (#{workflow_id}) runs: #{response.body}"
                                                                        ^^^^^^^^^^^
Did you mean?  workflow>     
```

https://github.com/eregon/truffleruby-gem-tracker/actions/runs/5172710387/jobs/9317311409