### PR TITLE
Repair async-io gem status fetching

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -48,7 +48,7 @@ gems:
   - name: ruby-concurrency/concurrent-ruby
     workflows: [ci.yml, experimental.yml]
   - name: socketry/async-io
-    workflows: [development.yml]
+    workflows: [test.yaml]
   - name: socketry/nio4r
     workflows: [workflow.yml]
   - name: socketry/console


### PR DESCRIPTION
Before:
```
bin/gem_tracker status async-io
async-io ? #<RuntimeError: GitHub workflow development.yml no longer exists on main>
Failing CIs: socketry/async-io
```

After
```
bin/gem_tracker status async-io
async-io ✗ 18-06-2023 truffleruby on ubuntu                    https://github.com/socketry/async-io/actions/runs/5301140755/jobs/9595195919
Failing CIs: socketry/async-io
```