### PR TITLE
Fix `devise-two-factor` gem's status

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -222,7 +222,7 @@ gems:
     workflows: [ruby.yml]
   - name: braze-inc/knapsack
     workflows: [ruby.yml]
-  - name: tinfoil/devise-two-factor
+  - name: devise-two-factor/devise-two-factor
     workflows: [ci.yml]
   - name: rubysec/bundler-audit
     workflows: [ruby.yml]

--- a/lib/gem_tracker/ci/github.rb
+++ b/lib/gem_tracker/ci/github.rb
@@ -70,6 +70,11 @@ class GemTracker::GitHubActions < GemTracker::CI
   def get_repository
     repo_url = "https://api.github.com/repos/#{gem.name}"
     request(repo_url) do |response|
+      # detect a case when e.g. a repository is moved into another organization/user account
+      unless response.code.start_with?("20") # expect 20x status
+        raise "HTTP Error (#{response.code}) getting GitHub repository #{gem.name}: #{response.body}"
+      end
+
       JSON.parse(response.body)
     end
   end


### PR DESCRIPTION
Before
```
bin/gem_tracker status devise-two-factor
devise-two-factor ? #<KeyError: key not found: "default_branch">
Failing CIs: tinfoil/devise-two-factor
```

After
```
bin/gem_tracker status devise-two-factor
devise-two-factor ✓ 22-08-2023 Ruby truffleruby-head, Rails 7.0         https://github.com/devise-two-factor/devise-two-factor/actions/runs/5942179798/job/16114570346
```