### PR TITLE
Fix getting status of cucumber-ruby gem

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -236,7 +236,7 @@ gems:
   - name: dazuma/toys
     workflows: [ci.yml]
   - name: cucumber/cucumber-ruby
-    workflows: [cucumber-ruby.yml]
+    workflows: [test.yaml]
   - name: msgpack/msgpack-ruby
     workflows: [ci.yaml]
   - name: eregon/path


### PR DESCRIPTION
A workflow file was renamed.

Before:
```
bin/gem_tracker status cucumber-ruby
cucumber-ruby ? #<RuntimeError: GitHub workflow cucumber-ruby.yml no longer exists on main>
Failing CIs: cucumber/cucumber-ruby
```

After:
```
bin/gem_tracker status cucumber-ruby
cucumber-ruby ✓ 09-10-2023 test (ubuntu-latest, truffleruby-head)   https://github.com/cucumber/cucumber-ruby/actions/runs/6452550645/job/17514758617
```
