### PR TITLE
Fix status of rules_ruby gem and update its owner

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -273,7 +273,7 @@ gems:
     workflows: [main.yml]
   - name: SeleniumHQ/selenium
     workflows: [ci-ruby.yml]
-  - name: p0deje/rules_ruby
+  - name: bazel-contrib/rules_ruby
     workflows: [ci.yml]
   - name: rails/sprockets
     workflows: [ci.yml]


### PR DESCRIPTION
Before:

```
bin/gem_tracker status rules_ruby
rules_ruby ? #<RuntimeError: HTTP Error (301) getting GitHub repository p0deje/rules_ruby: {"message":"Moved Permanently","url":"https://api.github.com/repositories/537554611","documentation_url":"https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"}>
Failing CIs: p0deje/rules_ruby
```

After:

```
bin/gem_tracker status rules_ruby
rules_ruby ✓ 13-12-2023 Examples / Gem (truffleruby-23.1.1, ...) https://github.com/bazel-contrib/rules_ruby/actions/runs/7188754899/job/19579025894
```