### PR TITLE
Update puma workflow name

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -50,7 +50,7 @@ gems:
   - name: rack/rack
     workflows: [test.yaml]
   - name: puma/puma
-    workflows: [tests.yaml]
+    workflows: [tests.yml]
   - name: ruby-concurrency/concurrent-ruby
     workflows: [ci.yml, experimental.yml]
   - name: socketry/async-io


### PR DESCRIPTION
Before:
```
bin/gem_tracker status puma
puma ? #<RuntimeError: GitHub workflow tests.yaml no longer exists on master>
Failing CIs: puma/puma
```

After:
```
bin/gem_tracker status puma
puma ✗ 08-01-2024 NON-MRI: ubuntu-20.04 truffleruby        https://github.com/puma/puma/actions/runs/7443704580/job/20249070210
puma ✗ 08-01-2024 NON-MRI: ubuntu-20.04 truffleruby-head   https://github.com/puma/puma/actions/runs/7443704580/job/20249070339
puma ✗ 08-01-2024 NON-MRI: ubuntu-22.04 truffleruby        https://github.com/puma/puma/actions/runs/7443704580/job/20249070474
puma ✗ 08-01-2024 NON-MRI: ubuntu-22.04 truffleruby-head   https://github.com/puma/puma/actions/runs/7443704580/job/20249070618
puma ✓ 08-01-2024 NON-MRI: macos-12 truffleruby            https://github.com/puma/puma/actions/runs/7443704580/job/20249070887
Failing CIs: puma/puma
```