### PR TITLE
Update sqlite3-ruby workflow name to repair status fetching

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -270,7 +270,7 @@ gems:
   - name: cookpad/grpc_kit
     workflows: [ci.yml]
   - name: sparklemotion/sqlite3-ruby
-    workflows: [sqlite3-ruby.yml, gem-install.yml]
+    workflows: [ci.yml]
   - name: ruby-syntax-tree/syntax_tree
     workflows: [main.yml]
   - name: SeleniumHQ/selenium


### PR DESCRIPTION
Before
```
bin/gem_tracker status sqlite3-ruby
sqlite3-ruby ? #<RuntimeError: GitHub workflow sqlite3-ruby.yml no longer exists on main>
Failing CIs: sparklemotion/sqlite3-ruby
```
After:
```
bin/gem_tracker status sqlite3-ruby
sqlite3-ruby ✓ 21-02-2024 test (ubuntu, truffleruby, disable)      https://github.com/sparklemotion/sqlite3-ruby/actions/runs/7985968029/job/21805467716
```