### PR TITLE
Update workflow name for mechanize gem

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -209,7 +209,7 @@ gems:
   # - name: gazay/gon
   #   ci: none
   - name: sparklemotion/mechanize
-    workflows: [ci-test.yml]
+    workflows: [ci.yml, upstream.yml]
   - name: thoughtbot/factory_bot
     workflows: [build.yml]
   - name: kubo/ruby-oci8


### PR DESCRIPTION
Before:
```
$ bin/gem_tracker status mechanize
mechanize ? #<RuntimeError: GitHub workflow ci-test.yml no longer exists on main>
Failing CIs: sparklemotion/mechanize
```

After:
```
$ bin/gem_tracker status mechanize
mechanize ✓ 19-04-2024 test (truffleruby...)                    https://github.com/sparklemotion/mechanize/actions/runs/8750380010/job/24013819725
```