### PR TITLE
Repair nio4r gem's workflow name

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -60,7 +60,7 @@ gems:
   - name: socketry/async-io
     workflows: [test.yaml]
   - name: socketry/nio4r
-    workflows: [workflow.yml]
+    workflows: [test.yaml]
   - name: socketry/console
     workflows: [test.yaml]
   - name: ffi/ffi


### PR DESCRIPTION
Before:

```
bin/gem_tracker status nio4r
nio4r ? #<RuntimeError: GitHub workflow workflow.yml no longer exists on main>
Failing CIs: socketry/nio4r
```

After:

```
bin/gem_tracker status nio4r
nio4r ✓ 07-05-2024 ..., truffleruby                         https://github.com/socketry/nio4r/actions/runs/8992061512/job/24701011971
```