### PR TITLE
Update workflow name for the minitar gem

### DIFF
--- a/gems.yml
+++ b/gems.yml
@@ -271,7 +271,7 @@ gems:
   - name: bazel-contrib/rules_ruby
     workflows: [ci.yml]
   - name: halostatue/minitar
-    workflows: [ruby.yml]
+    workflows: [ci.yml]
   - name: piotrmurach/tty-option
     workflows: [ci.yml]
   # - name: phlex-ruby/phlex


### PR DESCRIPTION
Before:
```
$ bin/gem_tracker status minitar
minitar ? #<RuntimeError: GitHub workflow ruby.yml no longer exists on main>

Unknown CIs: halostatue/minitar
```

After:
```
$ bin/gem_tracker status minitar
minitar ✓ 24-03-2025 Ruby truffleruby - ubuntu-2....04        https://github.com/halostatue/minitar/actions/runs/14038046947/job/39300919969
```